### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:latest as builder
+FROM rust:buster as builder
 RUN apt-get update && apt-get install -y libgdal-dev
 WORKDIR /usr/src/myapp
 COPY . .


### PR DESCRIPTION
Default Debian version was bumped for Rust 1.55 to bullseye.